### PR TITLE
docs: fix shell quoting for cross-platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ project/ (5 files, 14 lines total)
 Expanded trees show format-specific heading labels:
 
 ```bash
-$ mq project/ '.tree("expand")'
+$ mq project/ ".tree('expand')"
 project/ (5 files)
 ├── config.json (12 lines, 3 keys)
 │   ├── key name
@@ -95,8 +95,8 @@ Any AI agent or coding assistant that can execute shell commands.
 
 ```bash
 # Markdown - structure and extraction
-mq docs/ '.tree("full")'
-mq docs/auth.md '.section("OAuth Flow") | .text'
+mq docs/ ".tree('full')"
+mq docs/auth.md ".section('OAuth Flow') | .text"
 
 # HTML - readable content from web pages
 mq page.html '.headings'
@@ -261,10 +261,12 @@ See [skills.sh](https://skills.sh) for more.
 Skills aren't always loaded into context. Add this line to your `CLAUDE.md` for optimal performance:
 
 ```markdown
-Use `mq` to query markdown files. Narrow down to a specific file/subdir first, then run `mq <path> '.tree("full")'` to see structure before reading.
+Use `mq` to query markdown files. Narrow down to a specific file/subdir first, then run `mq <path> ".tree('full')"` to see structure before reading.
 ```
 
 ## Usage
+
+> **Shell quoting:** Examples use double quotes for the outer string (`"..."`), which works on all platforms including Windows. On macOS and Linux, single quotes also work: `mq doc.md '.tree("full")'`.
 
 ### See Structure
 
@@ -273,34 +275,34 @@ Use `mq` to query markdown files. Narrow down to a specific file/subdir first, t
 mq README.md .tree
 
 # With content previews
-mq README.md '.tree("preview")'
+mq README.md ".tree('preview')"
 
 # Directory overview
 mq docs/ .tree
 
 # Directory with sections + previews (best for agents)
-mq docs/ '.tree("full")'
+mq docs/ ".tree('full')"
 ```
 
 ### Search
 
 ```bash
 # Search in file
-mq README.md '.search("OAuth")'
+mq README.md ".search('OAuth')"
 
 # Search across directory
-mq docs/ '.search("authentication")'
+mq docs/ ".search('authentication')"
 ```
 
 ### Extract Content
 
 ```bash
 # Get section content
-mq doc.md '.section("API") | .text'
+mq doc.md ".section('API') | .text"
 
 # Get code blocks
-mq doc.md '.code("python")'
-mq doc.md '.section("Examples") | .code("go")'
+mq doc.md ".code('python')"
+mq doc.md ".section('Examples') | .code('go')"
 
 # Get links, metadata
 mq doc.md .links
@@ -339,9 +341,9 @@ mq uses a jq-inspired query syntax with piping and selectors. If you're familiar
 ### Examples
 
 ```bash
-mq doc.md '.headings | filter(.level == 2) | .text'
-mq doc.md '.section("Examples") | .code("python")'
-mq doc.md '.section("API") | .tree'
+mq doc.md ".headings | filter(.level == 2) | .text"
+mq doc.md ".section('Examples') | .code('python')"
+mq doc.md ".section('API') | .tree"
 ```
 
 ## Architecture

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -8,8 +8,8 @@ mq is inspired by jq's piping model and query syntax, but designed specifically 
 
 **Piping** - Chain operations with `|`:
 ```bash
-mq doc.md '.section("API") | .code("go")'
-mq doc.md '.headings | filter(.level == 2)'
+mq doc.md ".section('API') | .code('go')"
+mq doc.md ".headings | filter(.level == 2)"
 ```
 
 **Indexing** - Access elements by position:
@@ -26,7 +26,7 @@ mq doc.md '.code | filter(.lang == "python")'
 
 **Chaining** - Compose multiple operations:
 ```bash
-mq doc.md '.section("Examples") | .code("python") | .[0]'
+mq doc.md ".section('Examples') | .code('python') | .[0]"
 ```
 
 ## Key Differences (and Why)
@@ -39,8 +39,8 @@ mq doc.md '.section("Examples") | .code("python") | .[0]'
 ```bash
 # This is necessary because markdown sections are identified by heading text,
 # not implicit keys like JSON fields
-mq doc.md '.section("Installation")'
-mq doc.md '.code("python")'
+mq doc.md ".section('Installation')"
+mq doc.md ".code('python')"
 ```
 
 **Why**: In JSON, fields have explicit keys. In markdown, sections are identified by their heading text. We can't magically know which section you want without the title.
@@ -53,8 +53,8 @@ mq doc.md '.code("python")'
 ```bash
 # mq syntax
 mq doc.md .tree
-mq doc.md '.tree("full")'
-mq doc.md '.section("API") | .text'
+mq doc.md ".tree('full')"
+mq doc.md ".section('API') | .text"
 
 # We chose this because it's cleaner - not every operation needs to be piped
 ```
@@ -67,7 +67,7 @@ mq doc.md '.section("API") | .text'
 **mq**: `| .text` is a selector
 
 ```bash
-mq doc.md '.section("API") | .text'
+mq doc.md ".section('API') | .text"
 ```
 
 **Why**: Same reason as above - cleaner syntax. Text extraction is so common in markdown querying that making it a selector reduces verbosity.
@@ -79,20 +79,20 @@ mq doc.md '.section("API") | .text'
 | Selector | Description | Example |
 |----------|-------------|---------|
 | `.tree` | Document structure | `mq doc.md .tree` |
-| `.tree("compact")` | Headings only | `mq doc.md '.tree("compact")'` |
-| `.tree("preview")` | Headings + preview | `mq doc.md '.tree("preview")'` |
-| `.tree("full")` | Sections + previews (dirs) | `mq docs/ '.tree("full")'` |
+| `.tree("compact")` | Headings only | `mq doc.md ".tree('compact')"` |
+| `.tree("preview")` | Headings + preview | `mq doc.md ".tree('preview')"` |
+| `.tree("full")` | Sections + previews (dirs) | `mq docs/ ".tree('full')"` |
 
 ### Content Selectors
 
 | Selector | Description | Example |
 |----------|-------------|---------|
-| `.section("name")` | Section by heading | `mq doc.md '.section("API")'` |
+| `.section("name")` | Section by heading | `mq doc.md ".section('API')"` |
 | `.sections` | All sections | `mq doc.md .sections` |
 | `.headings` | All headings | `mq doc.md .headings` |
 | `.headings(N)` | Headings at level N | `mq doc.md '.headings(2)'` |
 | `.code` | All code blocks | `mq doc.md .code` |
-| `.code("lang")` | Code blocks by language | `mq doc.md '.code("python")'` |
+| `.code("lang")` | Code blocks by language | `mq doc.md ".code('python')"` |
 | `.links` | All links | `mq doc.md .links` |
 | `.images` | All images | `mq doc.md .images` |
 | `.tables` | All tables | `mq doc.md .tables` |
@@ -101,7 +101,7 @@ mq doc.md '.section("API") | .text'
 
 | Selector | Description | Example |
 |----------|-------------|---------|
-| `.search("term")` | Find sections with term | `mq doc.md '.search("auth")'` |
+| `.search("term")` | Find sections with term | `mq doc.md ".search('auth')"` |
 | `.metadata` | YAML frontmatter | `mq doc.md .metadata` |
 | `.owner` | Owner field from metadata | `mq doc.md .owner` |
 | `.tags` | Tags from metadata | `mq doc.md .tags` |
@@ -110,7 +110,7 @@ mq doc.md '.section("API") | .text'
 
 | Selector | Description | Example |
 |----------|-------------|---------|
-| `.text` | Extract raw text | `mq doc.md '.section("API") \| .text'` |
+| `.text` | Extract raw text | `mq doc.md ".section('API') \| .text"` |
 
 ## Operations
 
@@ -118,8 +118,8 @@ mq doc.md '.section("API") | .text'
 
 Chain selectors with `|`:
 ```bash
-mq doc.md '.section("Examples") | .code("go")'
-mq doc.md '.headings | filter(.level == 2) | .text'
+mq doc.md ".section('Examples') | .code('go')"
+mq doc.md ".headings | filter(.level == 2) | .text"
 ```
 
 ### Indexing
@@ -148,16 +148,16 @@ mq doc.md '.links | filter(.text contains "API")'
 mq docs/api.md .tree
 
 # Then extract specific section
-mq docs/api.md '.section("Authentication") | .text'
+mq docs/api.md ".section('Authentication') | .text"
 ```
 
 ### Search then Refine
 ```bash
 # Search for sections about auth
-mq docs/ '.search("authentication")'
+mq docs/ ".search('authentication')"
 
 # Refine to specific file and section
-mq docs/auth.md '.section("OAuth Flow") | .code("javascript")'
+mq docs/auth.md ".section('OAuth Flow') | .code('javascript')"
 ```
 
 ### Filter by Level
@@ -175,10 +175,10 @@ mq doc.md '.sections | filter(.level == 1)'
 mq docs/ .tree
 
 # Full structure with previews (best for agents)
-mq docs/ '.tree("full")'
+mq docs/ ".tree('full')"
 
 # Search across directory
-mq docs/ '.search("error handling")'
+mq docs/ ".search('error handling')"
 ```
 
 ## For Agent Integration
@@ -197,7 +197,7 @@ When integrating mq into agent workflows, follow this pattern:
 
 3. **Extract only what's needed** - Pull specific sections
    ```bash
-   mq docs/api.md '.section("Error Codes") | .text'
+   mq docs/api.md ".section('Error Codes') | .text"
    ```
 
 This structure-first approach reduces token usage by 50-83% compared to reading full files.

--- a/skills/mq/SKILL.md
+++ b/skills/mq/SKILL.md
@@ -14,9 +14,9 @@ Documents → mq query → Structure enters your context → You reason → Resu
 ## The Pattern
 
 ```
-1. See structure    →  mq <path> .tree           → Map enters your context
-2. Find relevant    →  mq <path> '.search("x")'  → Locations enter your context
-3. Extract content  →  mq <path> '.section("Y") | .text'  → Content enters your context
+1. See structure    →  mq <path> .tree            → Map enters your context
+2. Find relevant    →  mq <path> ".search('x')"   → Locations enter your context
+3. Extract content  →  mq <path> ".section('Y') | .text"  → Content enters your context
 4. Reason           →  You compute the answer from what's now in your context
 ```
 
@@ -27,17 +27,17 @@ Your context accumulates structure. You do the final reasoning.
 ```bash
 # Structure (your working index)
 mq file.md .tree                    # Document structure
-mq file.md '.tree("preview")'       # Structure + content previews
+mq file.md ".tree('preview')"       # Structure + content previews
 mq dir/ .tree                       # Directory overview
-mq dir/ '.tree("full")'             # All files with sections + previews
+mq dir/ ".tree('full')"             # All files with sections + previews
 
 # Search
-mq file.md '.search("term")'        # Find sections containing term
-mq dir/ '.search("term")'           # Search across all files
+mq file.md ".search('term')"        # Find sections containing term
+mq dir/ ".search('term')"           # Search across all files
 
 # Extract
-mq file.md '.section("Name") | .text'   # Get section content
-mq file.md '.code("python")'            # Get code blocks by language
+mq file.md ".section('Name') | .text"   # Get section content
+mq file.md ".code('python')"            # Get code blocks by language
 mq file.md .links                       # Get all links
 mq file.md .metadata                    # Get YAML frontmatter
 ```
@@ -51,7 +51,7 @@ mq file.md .metadata                    # Get YAML frontmatter
 mq README.md .tree
 
 # For a directory (start here for multi-file exploration)
-mq docs/ '.tree("full")'
+mq docs/ ".tree('full')"
 ```
 
 Output shows you the territory:
@@ -71,7 +71,7 @@ Now you know: API.md has auth info, 234 lines, section called "Authentication".
 If you need something specific but don't know where:
 
 ```bash
-mq docs/ '.search("OAuth")'
+mq docs/ ".search('OAuth')"
 ```
 
 Output points you to exact locations:
@@ -91,7 +91,7 @@ Now you know: auth.md, section "OAuth Flow", lines 45-67.
 Don't read the whole file. Extract the section:
 
 ```bash
-mq docs/auth.md '.section("OAuth Flow") | .text'
+mq docs/auth.md ".section('OAuth Flow') | .text"
 ```
 
 This returns just that section's content.
@@ -106,7 +106,7 @@ cat docs/auth.md  # Wastes tokens on irrelevant content
 **Good**: Query then extract
 ```bash
 mq docs/auth.md .tree                           # See structure
-mq docs/auth.md '.section("OAuth Flow") | .text'  # Get only what's needed
+mq docs/auth.md ".section('OAuth Flow') | .text"  # Get only what's needed
 ```
 
 **Bad**: Re-querying structure you already have
@@ -119,7 +119,7 @@ mq docs/ .tree    # Again - wasteful, you already have this in context
 ```bash
 mq docs/ .tree    # Once - now you know the structure
 # Use the structure you learned to make targeted queries
-mq docs/auth.md '.section("OAuth") | .text'
+mq docs/auth.md ".section('OAuth') | .text"
 ```
 
 ## Context as Working Memory
@@ -135,7 +135,7 @@ Query 2: mq docs/auth.md .tree
 → You now see: auth.md's full section hierarchy
 → You can reason: "OAuth Flow section has what I need"
 
-Query 3: mq docs/auth.md '.section("OAuth Flow") | .text'
+Query 3: mq docs/auth.md ".section('OAuth Flow') | .text"
 → You now have: the actual content
 → You can reason: compute the final answer
 ```
@@ -146,25 +146,25 @@ mq externalizes structure. You do the thinking. Don't re-query what you already 
 
 ### "Find how authentication works"
 ```bash
-mq docs/ '.search("auth")'           # Find relevant files/sections
-mq docs/auth.md '.section("Overview") | .text'  # Read the overview
+mq docs/ ".search('auth')"           # Find relevant files/sections
+mq docs/auth.md ".section('Overview') | .text"  # Read the overview
 ```
 
 ### "Get all Python examples"
 ```bash
-mq docs/ '.tree("full")'             # Find files with examples
-mq docs/examples.md '.code("python")'  # Extract all Python code
+mq docs/ ".tree('full')"             # Find files with examples
+mq docs/examples.md ".code('python')"  # Extract all Python code
 ```
 
 ### "Understand the API structure"
 ```bash
 mq docs/api.md .tree                 # See all endpoints/sections
-mq docs/api.md '.section("Endpoints") | .tree'  # Drill into endpoints
-mq docs/api.md '.section("POST /users") | .text'  # Get specific endpoint
+mq docs/api.md ".section('Endpoints') | .tree"  # Drill into endpoints
+mq docs/api.md ".section('POST /users') | .text"  # Get specific endpoint
 ```
 
 ### "Find configuration options"
 ```bash
-mq . '.search("config")'             # Search entire project
-mq config.md '.section("Options") | .text'  # Extract options
+mq . ".search('config')"             # Search entire project
+mq config.md ".section('Options') | .text"  # Extract options
 ```


### PR DESCRIPTION
## Summary
- Updated all CLI examples in README.md, SKILL.md, and docs/syntax.md to use double quotes for the outer string (`"...'...'"`) which works on all platforms including Windows
- Added a shell quoting note in README.md explaining that macOS/Linux users can also use single quotes
- Fixes #1

## Context
Windows `cmd.exe` doesn't recognize single quotes as string delimiters, so examples like `mq doc.md '.tree("full")'` fail. The new format `mq doc.md ".tree('full')"` works everywhere.