### PR TITLE
feat: line-level JSONL search and .record(N) selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ AI agents waste tokens reading entire files. mq lets them query structure first,
 | HTML | `.html`, `.htm` | Headings, readable content (Readability algorithm) |
 | PDF | `.pdf` | Headings (font-size inference), tables, text |
 | JSON | `.json` | Top-level keys as headings, nested structure |
-| JSONL | `.jsonl`, `.ndjson` | Uniform objects as tables, mixed as items |
+| JSONL | `.jsonl`, `.ndjson` | Line-level search, per-record drill-in |
 | YAML | `.yaml`, `.yml` | Keys as headings, nested structure |
 
 ### Directory Tree Labels
@@ -110,8 +110,9 @@ mq paper.pdf '.tables'
 mq config.json '.headings'      # Top-level keys
 mq data.yaml '.text'            # Readable representation
 
-# JSONL - query ML datasets and logs
-mq users.jsonl '.tables'        # Uniform objects as tables
+# JSONL - search logs and session files
+mq session.jsonl '.search("auth")'  # Line-level search with record context
+mq session.jsonl '.record(7)'       # Pretty-print specific record
 ```
 
 ## Why This Works
@@ -292,6 +293,15 @@ mq README.md ".search('OAuth')"
 
 # Search across directory
 mq docs/ ".search('authentication')"
+
+# JSONL: line-level search with record type + structure
+mq session.jsonl ".search('auth')"
+# → [line 3] assistant/tool_use: Grep
+#     ts: 2026-02-01T20:25:34Z
+#     > ...searching for auth configuration...
+
+# Drill into a specific record
+mq session.jsonl ".record(3)"
 ```
 
 ### Extract Content
@@ -321,7 +331,8 @@ mq uses a jq-inspired query syntax with piping and selectors. If you're familiar
 | `.tree("compact")` | Headings only |
 | `.tree("preview")` | Headings + content preview |
 | `.tree("full")` | Sections + previews (directories) |
-| `.search("term")` | Find sections containing term |
+| `.search("term")` | Find sections containing term (JSONL: line-level) |
+| `.record(N)` | Get JSONL record at line N (pretty-printed) |
 | `.section("name")` | Section by heading |
 | `.sections` | All sections |
 | `.headings` | All headings |

--- a/docs/library.md
+++ b/docs/library.md
@@ -247,6 +247,7 @@ result, err := engine.Query(doc, `.section("API") | .code("go")`)
 | `.links` | All links |
 | `.images` | All images |
 | `.tables` | All tables |
+| `.record(N)` | JSONL record at line N |
 | `.metadata` | Frontmatter metadata |
 | `.text` | Extract text content |
 | `.tree` | Document structure |

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -97,11 +97,12 @@ mq doc.md ".section('API') | .text"
 | `.images` | All images | `mq doc.md .images` |
 | `.tables` | All tables | `mq doc.md .tables` |
 
-### Search & Metadata
+### Search & Navigation
 
 | Selector | Description | Example |
 |----------|-------------|---------|
 | `.search("term")` | Find sections with term | `mq doc.md ".search('auth')"` |
+| `.record(N)` | JSONL: get record at line N | `mq log.jsonl '.record(7)'` |
 | `.metadata` | YAML frontmatter | `mq doc.md .metadata` |
 | `.owner` | Owner field from metadata | `mq doc.md .owner` |
 | `.tags` | Tags from metadata | `mq doc.md .tags` |
@@ -158,6 +159,18 @@ mq docs/ ".search('authentication')"
 
 # Refine to specific file and section
 mq docs/auth.md ".section('OAuth Flow') | .code('javascript')"
+```
+
+### JSONL: Search then Drill In
+```bash
+# Search returns line numbers with record type context
+mq session.jsonl ".search('error')"
+# → [line 14] assistant/tool_use: Bash
+#     ts: 2026-02-01T20:25:38Z
+#     > ...command failed with error...
+
+# Drill into the full record
+mq session.jsonl '.record(14)'
 ```
 
 ### Filter by Level

--- a/lib/document.go
+++ b/lib/document.go
@@ -1,6 +1,11 @@
 package mq
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/yuin/goldmark/ast"
@@ -358,4 +363,43 @@ func (d *Document) GetTableOfContents() []*Section {
 // Walk traverses the document AST with a visitor function.
 func (d *Document) Walk(visitor func(ast.Node, bool) (ast.WalkStatus, error)) error {
 	return ast.Walk(d.root, visitor)
+}
+
+// GetRecord returns a specific line from a JSONL file, parsed and pretty-printed.
+// Line numbers are 1-based (matching search output).
+func (d *Document) GetRecord(lineNum int) (string, error) {
+	if d.format != FormatJSONL {
+		return "", fmt.Errorf(".record() only works on JSONL files, this is %s", d.format)
+	}
+	if lineNum < 1 {
+		return "", fmt.Errorf("line number must be >= 1, got %d", lineNum)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(d.source))
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+
+	current := 0
+	for scanner.Scan() {
+		current++
+		if current == lineNum {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				return "", fmt.Errorf("line %d is empty", lineNum)
+			}
+
+			// Parse and pretty-print
+			var obj interface{}
+			if err := json.Unmarshal([]byte(line), &obj); err != nil {
+				return line, nil // Return raw line if not valid JSON
+			}
+
+			pretty, err := json.MarshalIndent(obj, "", "  ")
+			if err != nil {
+				return line, nil
+			}
+			return string(pretty), nil
+		}
+	}
+
+	return "", fmt.Errorf("line %d not found (file has %d lines)", lineNum, current)
 }

--- a/lib/tree.go
+++ b/lib/tree.go
@@ -1,6 +1,9 @@
 package mq
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -256,10 +259,11 @@ func getPrefix(depth int, hasMore bool) string {
 
 // SearchResult represents a search match with section context.
 type SearchResult struct {
-	File    string // File path
-	Section string // Section heading
-	Lines   string // Line range (e.g., "34-89")
-	Match   string // Snippet with match context
+	File    string   // File path
+	Section string   // Section heading or record label
+	Lines   string   // Line range (e.g., "34-89") or single line
+	Match   string   // Snippet with match context
+	Fields  []string // Key-value fields from the record (JSONL only)
 }
 
 // SearchResults holds all search matches.
@@ -292,9 +296,15 @@ func isTraversalFile(path string) bool {
 }
 
 // Search finds sections containing the query term.
+// For JSONL files, searches line by line for per-record granularity.
+// For other formats, searches by section.
 func (d *Document) Search(query string) *SearchResults {
+	if d.format == FormatJSONL {
+		return d.searchJSONL(query)
+	}
+
 	results := &SearchResults{Query: query}
-	query = strings.ToLower(query)
+	queryLower := strings.ToLower(query)
 	hasSearchableSections := false
 
 	for _, section := range d.GetSections() {
@@ -303,8 +313,7 @@ func (d *Document) Search(query string) *SearchResults {
 			continue
 		}
 		hasSearchableSections = true
-		if strings.Contains(strings.ToLower(text), query) {
-			// Find a snippet around the match
+		if strings.Contains(strings.ToLower(text), queryLower) {
 			snippet := extractSnippet(text, query, 60)
 			results.Matches = append(results.Matches, &SearchResult{
 				File:    d.path,
@@ -319,7 +328,7 @@ func (d *Document) Search(query string) *SearchResults {
 	// Fall back to readable text so directory search works across all formats.
 	if !hasSearchableSections {
 		text := d.ReadableText()
-		if strings.Contains(strings.ToLower(text), query) {
+		if strings.Contains(strings.ToLower(text), queryLower) {
 			section := d.Title()
 			if section == "" {
 				section = "Document"
@@ -334,6 +343,165 @@ func (d *Document) Search(query string) *SearchResults {
 	}
 
 	return results
+}
+
+// searchJSONL searches a JSONL file line by line for per-record matches.
+// Pure text search first, then JSON parse only on matching lines to extract
+// record structure for display.
+func (d *Document) searchJSONL(query string) *SearchResults {
+	results := &SearchResults{Query: query}
+	queryLower := strings.ToLower(query)
+
+	scanner := bufio.NewScanner(bytes.NewReader(d.source))
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if !strings.Contains(strings.ToLower(trimmed), queryLower) {
+			continue
+		}
+
+		// Only parse JSON for matching lines to extract structure
+		label, fields := jsonlRecordInfo(trimmed)
+		snippet := extractSnippet(trimmed, query, 80)
+
+		results.Matches = append(results.Matches, &SearchResult{
+			File:    d.path,
+			Section: label,
+			Lines:   fmt.Sprintf("%d", lineNum),
+			Match:   snippet,
+			Fields:  fields,
+		})
+	}
+
+	return results
+}
+
+// jsonlRecordInfo extracts a label and key fields from a JSONL record.
+// Returns a short label for the heading and a list of "key: value" strings
+// showing the record's structure. Only parses JSON for matched lines.
+func jsonlRecordInfo(line string) (string, []string) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(line), &obj); err != nil {
+		return "record", nil
+	}
+
+	var label string
+	var fields []string
+
+	// Claude session format detection
+	typ, hasType := obj["type"].(string)
+	if hasType {
+		label = typ
+		msg, hasMsg := obj["message"].(map[string]interface{})
+
+		if hasMsg {
+			role, _ := msg["role"].(string)
+			if role != "" {
+				label = typ + "/" + role
+			}
+
+			// Dig into content blocks for tool info
+			if content, ok := msg["content"].([]interface{}); ok {
+				for _, block := range content {
+					m, ok := block.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					blockType, _ := m["type"].(string)
+					switch blockType {
+					case "tool_use":
+						name, _ := m["name"].(string)
+						if name != "" {
+							label = fmt.Sprintf("%s/tool_use: %s", typ, name)
+						}
+					case "tool_result":
+						label = typ + "/tool_result"
+					case "text":
+						// Show a preview of the text content
+						if text, ok := m["text"].(string); ok && len(text) > 0 {
+							preview := text
+							if len(preview) > 120 {
+								preview = preview[:120] + "..."
+							}
+							fields = append(fields, "text: "+preview)
+						}
+					case "thinking":
+						fields = append(fields, "thinking: (present)")
+					}
+				}
+			}
+
+			// String content (user messages)
+			if content, ok := msg["content"].(string); ok && len(content) > 0 {
+				preview := content
+				if len(preview) > 120 {
+					preview = preview[:120] + "..."
+				}
+				fields = append(fields, "content: "+preview)
+			}
+		}
+
+		// Add timestamp if present
+		if ts, ok := obj["timestamp"].(string); ok {
+			fields = append(fields, "ts: "+ts)
+		}
+
+		return label, fields
+	}
+
+	// Generic JSONL: show top-level scalar fields
+	label = "record"
+	for _, key := range []string{"name", "id", "type", "role", "action", "event", "level", "status"} {
+		if v, ok := obj[key].(string); ok {
+			if label == "record" {
+				label = key + ": " + v
+			}
+			fields = append(fields, key+": "+v)
+		}
+	}
+
+	// Show remaining scalar fields (up to a few)
+	shown := len(fields)
+	for k, v := range obj {
+		if shown >= 6 {
+			break
+		}
+		switch val := v.(type) {
+		case string:
+			entry := k + ": " + val
+			if len(val) > 80 {
+				entry = k + ": " + val[:80] + "..."
+			}
+			// Avoid duplicating keys already shown
+			dup := false
+			for _, f := range fields {
+				if strings.HasPrefix(f, k+": ") {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				fields = append(fields, entry)
+				shown++
+			}
+		case float64:
+			fields = append(fields, fmt.Sprintf("%s: %v", k, val))
+			shown++
+		case bool:
+			fields = append(fields, fmt.Sprintf("%s: %v", k, val))
+			shown++
+		}
+	}
+
+	return label, fields
 }
 
 // extractSnippet extracts text around the first match.
@@ -386,9 +554,12 @@ func (r *SearchResults) String() string {
 			buf.WriteString(fmt.Sprintf("%s:\n", m.File))
 			currentFile = m.File
 		}
-		buf.WriteString(fmt.Sprintf("  ## %s (lines %s)\n", m.Section, m.Lines))
+		buf.WriteString(fmt.Sprintf("  [line %s] %s\n", m.Lines, m.Section))
+		for _, field := range m.Fields {
+			buf.WriteString(fmt.Sprintf("    %s\n", field))
+		}
 		if m.Match != "" {
-			buf.WriteString(fmt.Sprintf("     %q\n", m.Match))
+			buf.WriteString(fmt.Sprintf("    > %s\n", m.Match))
 		}
 	}
 

--- a/mql/compiler.go
+++ b/mql/compiler.go
@@ -275,6 +275,16 @@ func (v *compilerVisitor) VisitSelector(node *SelectorNode) (interface{}, error)
 		}
 		return doc.Search(query), nil
 
+	case "record":
+		if len(args) == 0 {
+			return nil, fmt.Errorf("Error: .record requires a line number\nUsage: .record(7)\nHint: use .search(\"term\") to find line numbers first")
+		}
+		lineNum, ok := toInt(args[0])
+		if !ok {
+			return nil, fmt.Errorf("Error: .record requires an integer line number, got %T\nUsage: .record(7)", args[0])
+		}
+		return doc.GetRecord(lineNum)
+
 	default:
 		return nil, formatUnknownSelectorError(node.Name)
 	}
@@ -286,7 +296,7 @@ func formatUnknownSelectorError(name string) error {
 	knownSelectors := []string{
 		"headings", "section", "sections", "code", "links", "images",
 		"tables", "lists", "metadata", "owner", "tags", "priority",
-		"text", "length", "tree", "search",
+		"text", "length", "tree", "search", "record",
 	}
 
 	// Find closest match using simple string distance

--- a/skills/mq/SKILL.md
+++ b/skills/mq/SKILL.md
@@ -17,6 +17,7 @@ Documents → mq query → Structure enters your context → You reason → Resu
 1. See structure    →  mq <path> .tree            → Map enters your context
 2. Find relevant    →  mq <path> ".search('x')"   → Locations enter your context
 3. Extract content  →  mq <path> ".section('Y') | .text"  → Content enters your context
+                       mq <path> ".record(N)"     → (JSONL: full record at line N)
 4. Reason           →  You compute the answer from what's now in your context
 ```
 
@@ -34,12 +35,14 @@ mq dir/ ".tree('full')"             # All files with sections + previews
 # Search
 mq file.md ".search('term')"        # Find sections containing term
 mq dir/ ".search('term')"           # Search across all files
+mq log.jsonl ".search('error')"     # JSONL: line-level search with record context
 
 # Extract
 mq file.md ".section('Name') | .text"   # Get section content
 mq file.md ".code('python')"            # Get code blocks by language
 mq file.md .links                       # Get all links
 mq file.md .metadata                    # Get YAML frontmatter
+mq log.jsonl '.record(7)'               # JSONL: pretty-print record at line 7
 ```
 
 ## Efficient Workflow
@@ -143,6 +146,18 @@ Query 3: mq docs/auth.md ".section('OAuth Flow') | .text"
 mq externalizes structure. You do the thinking. Don't re-query what you already see.
 
 ## Examples by Task
+
+### "Find something in a JSONL session file"
+```bash
+mq session.jsonl ".search('deploy')"  # Line-level matches with record type
+# → [line 5] user/user
+#     content: Can you deploy the new version?
+#     ts: 2026-02-01T20:25:29Z
+# → [line 8] assistant/tool_use: Bash
+#     ts: 2026-02-01T20:25:34Z
+
+mq session.jsonl '.record(8)'         # Full pretty-printed JSON of that record
+```
 
 ### "Find how authentication works"
 ```bash


### PR DESCRIPTION
## Summary

- **JSONL search is now line-level**: `.search("term")` on JSONL files matches per-line instead of collapsing into one blob. Each match shows record type (user, assistant/tool_use, etc.), key fields (content preview, timestamp), and a match snippet.
- **New `.record(N)` selector**: drill into a specific JSONL line by number, pretty-prints the full JSON object. Follows the same pattern as markdown: `.search()` finds locations, `.record(N)` extracts content.
- **Search stays fast**: pure text matching on raw lines (no JSON parsing), then only parses matching lines to extract structure for display.

Before (1 useless match):
```
Found 1 matches for "agents-cli":
  ## Array (36 items) (lines n/a)
```

After (17 line-level matches with context):
```
Found 17 matches for "agents-cli":
  [line 1] user/user
    content: CAn we updaet the isntucitons here...
    ts: 2026-02-01T20:25:29.601Z
  [line 7] assistant/tool_use: Glob
    ts: 2026-02-01T20:25:34.373Z
```

## Test plan

- [x] `go test ./...` passes
- [ ] `mq session.jsonl '.search("term")'` returns line-level matches with record context
- [ ] `mq session.jsonl '.record(7)'` pretty-prints the JSON object at line 7
- [ ] `mq README.md '.search("term")'` still works (markdown search unchanged)
- [ ] `mq README.md '.record(1)'` gives clear error (JSONL only)
- [ ] `mq session.jsonl '.record(999)'` gives clear error (line not found)